### PR TITLE
CI: Add Ruby 3.2 and 3.1 and drop 2.6

### DIFF
--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -19,7 +19,7 @@ jobs:
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/macos-test.yml
+++ b/.github/workflows/macos-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7']
         os: [macos-latest]
         experimental: [false]
         include:

--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7']
         os: [ubuntu-latest]
         experimental: [false]
         include:

--- a/.github/workflows/ubuntu-test.yml
+++ b/.github/workflows/ubuntu-test.yml
@@ -19,7 +19,7 @@ jobs:
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -19,7 +19,7 @@ jobs:
 
     name: Unit testing with Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/windows-test.yml
+++ b/.github/workflows/windows-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['3.0', '2.7', '2.6']
+        ruby-version: ['3.2', '3.1', '3.0', '2.7']
         os: [windows-latest]
         experimental: [false]
         include:


### PR DESCRIPTION
The next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

I was checking each embedded plugin and noticed the Ruby versions being used in CI are not updated recently in this plugin.

How about updating them?

Ruby 2.6 is already EOL, so we can drop it.
